### PR TITLE
[Lean Squad] feat(fv): MedianFilter Lean spec + proofs; CI lake update; fix 8 linter warnings (run29)

### DIFF
--- a/.github/workflows/lean-ci.yml
+++ b/.github/workflows/lean-ci.yml
@@ -45,6 +45,9 @@ jobs:
           key: lean-lake-${{ steps.cache-key.outputs.manifest_hash }}
           restore-keys: lean-lake-
 
+      - name: Resolve Lean dependencies (lake update)
+        run: lake update
+
       - name: Build and verify all proofs
         run: |
           echo "=== lake build starting ==="

--- a/formal-verification/TARGETS.md
+++ b/formal-verification/TARGETS.md
@@ -24,7 +24,7 @@ rationale. Phase legend: 1=Research, 2=Informal Spec, 3=Lean Spec, 4=Implementat
 | 11 | `math::lerp` | `src/lib/mathlib/math/Functions.hpp` | 5 | ✅ Proved | `lean/FVSquad/Lerp.lean` | 9 proved, 1 sorry (lerp_half needs Rat inv arithmetic); informal spec written |
 | 12 | `math::expo` | `src/lib/mathlib/math/Functions.hpp` | 5 | ✅ Proved | `lean/FVSquad/Expo.lean` | RC stick curve; 12 theorems, 0 sorry (odd symmetry, range containment, fixed points) |
 | 13 | `math::negate<int16_t>` | `src/lib/mathlib/math/Functions.hpp` | 5 | ✅ Proofs — 🐛 Bug found | `lean/FVSquad/Negate.lean` | Overflow-safe negation; 13 theorems proved; non-involution bug found |
-| 14 | `MedianFilter` | `src/lib/mathlib/math/filter/MedianFilter.hpp` | 2 | 🔄 Informal Spec | — | Informal spec written (`specs/medianfilter_informal.md`); sorted window median; bounded by min/max |
+| 14 | `MedianFilter` | `src/lib/mathlib/math/filter/MedianFilter.hpp` | 5 | ✅ Proved | `lean/FVSquad/MedianFilter.lean` | 6 theorems + 6 concrete examples; spike rejection, range containment, head invariant |
 
 ## Non-Lean Targets (other tools recommended)
 

--- a/formal-verification/lean/FVSquad/AlphaFilter.lean
+++ b/formal-verification/lean/FVSquad/AlphaFilter.lean
@@ -80,7 +80,7 @@ theorem alphaUpdate_alpha_one (state sample : Rat) :
 
 /-- Upper no-overshoot: when `state ≤ sample`, the new state does not exceed `sample`. -/
 theorem alphaUpdate_le_sample (state alpha sample : Rat)
-    (h_le : state ≤ sample) (ha0 : 0 ≤ alpha) (ha1 : alpha ≤ 1) :
+    (h_le : state ≤ sample) (_ha0 : 0 ≤ alpha) (ha1 : alpha ≤ 1) :
     alphaUpdate state alpha sample ≤ sample := by
   simp only [alphaUpdate]
   -- key: alpha*(sample - state) ≤ 1*(sample - state) = sample - state
@@ -142,7 +142,7 @@ theorem alphaUpdate_le_state (state alpha sample : Rat)
 
     TODO: complete this proof. -/
 theorem alphaUpdate_ge_sample (state alpha sample : Rat)
-    (h_le : sample ≤ state) (ha0 : 0 ≤ alpha) (ha1 : alpha ≤ 1) :
+    (h_le : sample ≤ state) (_ha0 : 0 ≤ alpha) (ha1 : alpha ≤ 1) :
     sample ≤ alphaUpdate state alpha sample := by
   simp only [alphaUpdate]
   -- Need: sample ≤ state + alpha*(sample - state)
@@ -190,7 +190,7 @@ theorem alphaUpdate_mono_sample (state alpha : Rat)
 
 /-- Update is nondecreasing in initial state: larger `state` → larger output (alpha ≤ 1). -/
 theorem alphaUpdate_mono_state (alpha sample : Rat)
-    (ha1 : alpha ≤ 1) (ha0 : 0 ≤ alpha) (s1 s2 : Rat) (hs : s1 ≤ s2) :
+    (ha1 : alpha ≤ 1) (_ha0 : 0 ≤ alpha) (s1 s2 : Rat) (hs : s1 ≤ s2) :
     alphaUpdate s1 alpha sample ≤ alphaUpdate s2 alpha sample := by
   simp only [alphaUpdate]
   -- s1 + alpha*(sample - s1) ≤ s2 + alpha*(sample - s2)

--- a/formal-verification/lean/FVSquad/Basic.lean
+++ b/formal-verification/lean/FVSquad/Basic.lean
@@ -1,1 +1,13 @@
-def hello := "world"
+-- FVSquad barrel: re-exports all formal verification modules.
+import FVSquad.MathFunctions
+import FVSquad.SlewRate
+import FVSquad.Interpolate
+import FVSquad.Deadzone
+import FVSquad.WrapAngle
+import FVSquad.WelfordMean
+import FVSquad.AlphaFilter
+import FVSquad.Lerp
+import FVSquad.Expo
+import FVSquad.Negate
+import FVSquad.RingBuffer
+import FVSquad.MedianFilter

--- a/formal-verification/lean/FVSquad/Deadzone.lean
+++ b/formal-verification/lean/FVSquad/Deadzone.lean
@@ -145,7 +145,7 @@ theorem deadzone_neg (x dz : Rat) (hxdz : x < -dz) (hdz0 : 0 ≤ dz) (hdz1 : dz 
 
     The positive case is fully proved.
     The negative case uses `sorry` (needs Rat arithmetic; provable with Mathlib's `linarith`). -/
-theorem deadzone_le_one (x dz : Rat) (hx1 : x ≤ 1) (hdz0 : 0 ≤ dz) (hdz1 : dz < 1) :
+theorem deadzone_le_one (x dz : Rat) (hx1 : x ≤ 1) (_hdz0 : 0 ≤ dz) (hdz1 : dz < 1) :
     deadzone x dz ≤ 1 := by
   simp only [deadzone]
   split
@@ -193,7 +193,7 @@ theorem deadzone_le_one (x dz : Rat) (hx1 : x ≤ 1) (hdz0 : 0 ≤ dz) (hdz1 : d
     - Negative branch (x < −dz ≤ 0): output = (x+dz)/(1−dz).
       Since x ≥ −1, we have x+dz ≥ −1+dz = −(1−dz),
       so output ≥ −(1−dz)/(1−dz) = −1. -/
-theorem deadzone_ge_neg_one (x dz : Rat) (hxm1 : -1 ≤ x) (hdz0 : 0 ≤ dz) (hdz1 : dz < 1) :
+theorem deadzone_ge_neg_one (x dz : Rat) (hxm1 : -1 ≤ x) (_hdz0 : 0 ≤ dz) (hdz1 : dz < 1) :
     -1 ≤ deadzone x dz := by
   simp only [deadzone]
   split

--- a/formal-verification/lean/FVSquad/Expo.lean
+++ b/formal-verification/lean/FVSquad/Expo.lean
@@ -161,7 +161,7 @@ theorem expo_linear (v : Rat) : expoRat v 0 = constrainRat v (-1) 1 := by
 theorem expo_cubic (v : Rat) :
     expoRat v 1 = constrainRat v (-1) 1 * constrainRat v (-1) 1 * constrainRat v (-1) 1 := by
   have he : constrainRat 1 0 1 = 1 := by native_decide
-  simp only [expoRat, he, Rat.sub_self, Rat.zero_mul, Rat.zero_add, Rat.mul_one, Rat.one_mul]
+  simp only [expoRat, he, Rat.sub_self, Rat.zero_mul, Rat.zero_add, Rat.one_mul]
 
 /-- `expo` is an odd function: `expo(-v, e) = -expo(v, e)`.
     This preserves the sign of the stick input. -/
@@ -220,7 +220,7 @@ theorem expo_in_range (v e : Rat) : -1 ≤ expoRat v e ∧ expoRat v e ≤ 1 := 
 
 /-- The slope of expo at `v = 0` is `(1 - e)`.
     This confirms that `e` directly controls the centre sensitivity. -/
-theorem expo_eq_linear_at_zero (e : Rat) (h : 0 < e) (he : e ≤ 1) :
+theorem expo_eq_linear_at_zero (e : Rat) (_h : 0 < e) (_he : e ≤ 1) :
     ∀ δ : Rat, expoRat δ e - expoRat 0 e = (1 - constrainRat e 0 1) * constrainRat δ (-1) 1 +
               constrainRat e 0 1 * constrainRat δ (-1) 1 * constrainRat δ (-1) 1 * constrainRat δ (-1) 1 := by
   intro δ

--- a/formal-verification/lean/FVSquad/MedianFilter.lean
+++ b/formal-verification/lean/FVSquad/MedianFilter.lean
@@ -1,0 +1,211 @@
+/-!
+# MedianFilter — Formal Verification
+
+🔬 Lean Squad automated formal verification.
+
+This file models and proves correctness properties of `math::MedianFilter<T, WINDOW>`
+from PX4-Autopilot's mathlib:
+
+- **C++ source**: `src/lib/mathlib/math/filter/MedianFilter.hpp`
+- **Informal spec**: `formal-verification/specs/medianfilter_informal.md`
+
+## Model
+
+We model the filter over `Int` (exact arithmetic, no NaN/infinity).
+The C++ template operates over `float`, `double`, or integer types; our Lean model
+is an integer abstraction.
+
+The key operation is `median()`:
+
+```cpp
+T median() {
+    T sorted[WINDOW];
+    memcpy(sorted, _buffer, sizeof(_buffer));
+    qsort(&sorted, WINDOW, sizeof(T), cmp);
+    return sorted[WINDOW / 2];
+}
+```
+
+We model `median` as: sort a copy of the window list, return the element at index
+`length / 2`.
+
+## Proved properties
+
+| Theorem | Statement | Status |
+|---------|-----------|--------|
+| `mfMedian_mem` | Median is a member of the input window | ✅ Proved |
+| `mfMedian_const` | Constant window returns that value | ✅ Proved |
+| `mfMedian_ge_sorted_first` | Result ≥ smallest sorted element (window ≥ 3) | ✅ Proved |
+| `mfMedian_le_sorted_last` | Result ≤ largest sorted element (window ≥ 3) | ✅ Proved |
+| `mfInsert_lt` | Head stays in bounds after insert | ✅ Proved |
+| `mfInsert_head_wraps` | Head wraps to 0 after last slot | ✅ Proved |
+| 6× concrete `native_decide` examples | Window-3 and window-5 concrete values | ✅ Proved |
+
+## Approximations / Out of Scope
+
+- **NaN / infinity**: the C++ `cmp` comparator has special handling for non-finite
+  floats (sorted to the top). This is not modelled — our model uses total integer order.
+- **Zero-initialisation bias**: the C++ buffer is zero-initialised; early calls to
+  `median()` before `WINDOW` inserts return a mix of zeros and real samples.
+  Modelled abstractly as a pure `List Int` without the initialisation phase.
+- **`uint8_t` overflow**: `_head` is `uint8_t` in C++, capping at 255 elements.
+  We use `Nat` with explicit `% window` guards.
+- **`qsort` vs `mergeSort`**: functionally equivalent for total orders; we use
+  `List.mergeSort intLE` where `intLE` is a total, transitive Bool comparator.
+-/
+
+namespace PX4.MedianFilter
+
+-- ============================================================
+-- Part 0: Bool comparator for Int (required by List.mergeSort API)
+-- ============================================================
+
+/-- Bool comparator: `a ≤ b` -/
+private def intLE (a b : Int) : Bool := if a ≤ b then true else false
+
+private theorem intLE_total (a b : Int) : (intLE a b || intLE b a) = true := by
+  simp only [intLE]; rcases Int.le_total a b with h | h <;> simp [h]
+
+private theorem intLE_trans (a b c : Int) (h1 : intLE a b = true) (h2 : intLE b c = true) :
+    intLE a c = true := by
+  simp only [intLE] at *
+  by_cases hab : a ≤ b
+  · by_cases hbc : b ≤ c
+    · simp [Int.le_trans hab hbc]
+    · simp [hbc] at h2
+  · simp [hab] at h1
+
+private theorem intLE_iff (a b : Int) : intLE a b = true ↔ a ≤ b := by
+  simp only [intLE]; by_cases h : a ≤ b <;> simp [h]
+
+/-- Key lemma: `sorted[i] ≤ sorted[j]` for `i ≤ j`, where `sorted = l.mergeSort intLE`.
+
+    Proved using `List.pairwise_mergeSort` (stdlib) plus `List.pairwise_iff_getElem`. -/
+private theorem sorted_getElem_le (l : List Int) (i j : Nat)
+    (hi : i < l.length) (hj : j < l.length) (hij : i ≤ j) :
+    (l.mergeSort intLE)[i]'(by rwa [List.length_mergeSort]) ≤
+    (l.mergeSort intLE)[j]'(by rwa [List.length_mergeSort]) := by
+  rcases Nat.lt_or_eq_of_le hij with h | h
+  · rw [← intLE_iff]
+    exact List.pairwise_iff_getElem.mp (List.pairwise_mergeSort intLE_trans intLE_total l)
+      i j (by rwa [List.length_mergeSort]) (by rwa [List.length_mergeSort]) h
+  · subst h; exact Int.le_refl _
+
+-- ============================================================
+-- Part 1: Abstract median function
+-- ============================================================
+
+/-- Abstract median over an integer list: sort and return the middle element.
+
+    Models `MedianFilter<T, WINDOW>::median()` — sort a copy of the window buffer,
+    return `sorted[WINDOW / 2]`.
+
+    **Precondition**: `l` is non-empty (guaranteed by `static_assert(WINDOW >= 3)`). -/
+def mfMedian (l : List Int) (h : 0 < l.length) : Int :=
+  (l.mergeSort intLE)[l.length / 2]'(by rw [List.length_mergeSort]; omega)
+
+-- ============================================================
+-- Concrete examples (native_decide)
+-- ============================================================
+
+-- Window = 3: basic ordering
+-- [1, 5, 2] → sorted [1, 2, 5] → index 1 = 2
+example : mfMedian [1, 5, 2] (by decide) = 2 := by native_decide
+
+-- Window = 3: spike rejection — outlier 10 is discarded
+-- [10, 2, 3] → sorted [2, 3, 10] → index 1 = 3
+example : mfMedian [10, 2, 3] (by decide) = 3 := by native_decide
+
+-- Window = 3: negative values
+-- [-1, -5, -2] → sorted [-5, -2, -1] → index 1 = -2
+example : mfMedian [-1, -5, -2] (by decide) = -2 := by native_decide
+
+-- Window = 3: constant window
+example : mfMedian [4, 4, 4] (by decide) = 4 := by native_decide
+
+-- Window = 5: mixed values
+-- [3, 1, 4, 1, 5] → sorted [1, 1, 3, 4, 5] → index 2 = 3
+example : mfMedian [3, 1, 4, 1, 5] (by decide) = 3 := by native_decide
+
+-- Window = 5: constant window
+example : mfMedian [7, 7, 7, 7, 7] (by decide) = 7 := by native_decide
+
+-- ============================================================
+-- Theorem: median is a member of the input list
+-- ============================================================
+
+/-- **`mfMedian_mem`**: The median of any window is one of the window's elements.
+
+    This follows from `List.mem_mergeSort` (mergeSort preserves membership) and
+    `List.getElem_mem` (every element at a valid index is a member). -/
+theorem mfMedian_mem (l : List Int) (h : 0 < l.length) : mfMedian l h ∈ l := by
+  simp only [mfMedian]
+  rw [← List.mem_mergeSort]
+  exact List.getElem_mem _
+
+-- ============================================================
+-- Theorem: constant window returns the constant value
+-- ============================================================
+
+/-- **`mfMedian_const`**: The median of a constant window `[x, x, …, x]` is `x`.
+
+    Proof: every element of `(replicate n x).mergeSort intLE` equals `x`
+    (by `List.mem_replicate`); therefore the element at index `n / 2` equals `x`. -/
+theorem mfMedian_const (x : Int) (n : Nat) (hn : 0 < n) :
+    mfMedian (List.replicate n x) (by simp [List.length_replicate, hn]) = x := by
+  simp only [mfMedian, List.length_replicate]
+  have hbound : n / 2 < ((List.replicate n x).mergeSort intLE).length := by
+    rw [List.length_mergeSort, List.length_replicate]; omega
+  have hmem : ((List.replicate n x).mergeSort intLE)[n / 2]'hbound ∈
+      (List.replicate n x).mergeSort intLE := List.getElem_mem _
+  rw [List.mem_mergeSort] at hmem
+  exact (List.mem_replicate.mp hmem).2
+
+-- ============================================================
+-- Theorems: range containment (median ∈ [min, max])
+-- ============================================================
+
+/-- **`mfMedian_ge_sorted_first`**: For windows of length ≥ 3, the median is ≥ the
+    minimum element (the first element of the sorted copy).
+
+    Key: index 0 ≤ length / 2 for any length, so `sorted_getElem_le` applies. -/
+theorem mfMedian_ge_sorted_first (l : List Int) (h : 3 ≤ l.length) :
+    (l.mergeSort intLE)[0]'(by rw [List.length_mergeSort]; omega) ≤ mfMedian l (by omega) :=
+  sorted_getElem_le l 0 (l.length / 2) (by omega) (by omega) (by omega)
+
+/-- **`mfMedian_le_sorted_last`**: For windows of length ≥ 3, the median is ≤ the
+    maximum element (the last element of the sorted copy).
+
+    Key: length / 2 ≤ length - 1 for length ≥ 3 (odd window), so `sorted_getElem_le` applies. -/
+theorem mfMedian_le_sorted_last (l : List Int) (h : 3 ≤ l.length) :
+    mfMedian l (by omega) ≤
+    (l.mergeSort intLE)[l.length - 1]'(by rw [List.length_mergeSort]; omega) :=
+  sorted_getElem_le l (l.length / 2) (l.length - 1) (by omega) (by omega) (by omega)
+
+-- ============================================================
+-- Part 2: Circular buffer head invariant
+-- ============================================================
+
+/-- Model of `MedianFilter::insert`: advance the circular head by 1 modulo window.
+
+    C++ implementation: `_head = (_head + 1) % WINDOW`. -/
+def mfInsert (head window : Nat) (_h : head < window) : Nat := (head + 1) % window
+
+/-- **`mfInsert_lt`**: Head stays strictly within `[0, window)` after every insert.
+
+    Ensures the C++ head index is always a valid buffer index. -/
+theorem mfInsert_lt (head window : Nat) (hw : 0 < window) (hh : head < window) :
+    mfInsert head window hh < window :=
+  Nat.mod_lt _ hw
+
+/-- **`mfInsert_head_wraps`**: Inserting from the last slot wraps the head to 0.
+
+    This is the ring-wrap condition: after writing slot `window - 1`, the next write
+    targets slot 0. -/
+theorem mfInsert_head_wraps (window : Nat) (hw : 0 < window) :
+    mfInsert (window - 1) window (by omega) = 0 := by
+  simp only [mfInsert]
+  have : window - 1 + 1 = window := Nat.sub_add_cancel hw
+  rw [this, Nat.mod_self]
+
+end PX4.MedianFilter

--- a/formal-verification/lean/FVSquad/WrapAngle.lean
+++ b/formal-verification/lean/FVSquad/WrapAngle.lean
@@ -89,7 +89,7 @@ theorem wrapInt_lt_high (x low high : Int) (h : low < high) :
   omega
 
 /-- If `x` is already in `[low, high)`, `wrapInt` returns `x` unchanged. -/
-theorem wrapInt_in_range (x low high : Int) (h : low < high)
+theorem wrapInt_in_range (x low high : Int) (_h : low < high)
     (hlo : low ≤ x) (hhi : x < high) : wrapInt x low high = x := by
   unfold wrapInt
   rw [Int.emod_eq_of_lt (by omega) (by omega)]
@@ -101,21 +101,21 @@ theorem wrapInt_idempotent (x low high : Int) (h : low < high) :
   wrapInt_in_range _ _ _ h (wrapInt_ge_low x low high h) (wrapInt_lt_high x low high h)
 
 /-- Shifting `x` by one full period `(high - low)` is transparent to `wrapInt`. -/
-theorem wrapInt_periodic (x low high : Int) (h : low < high) :
+theorem wrapInt_periodic (x low high : Int) (_h : low < high) :
     wrapInt (x + (high - low)) low high = wrapInt x low high := by
   unfold wrapInt
   have heq : x + (high - low) - low = (x - low) + 1 * (high - low) := by omega
   rw [heq, Int.add_mul_emod_self_right]
 
 /-- Shifting `x` by any integer multiple `k` of the period is transparent. -/
-theorem wrapInt_periodic_k (x low high k : Int) (h : low < high) :
+theorem wrapInt_periodic_k (x low high k : Int) (_h : low < high) :
     wrapInt (x + k * (high - low)) low high = wrapInt x low high := by
   unfold wrapInt
   have heq : x + k * (high - low) - low = (x - low) + k * (high - low) := by omega
   rw [heq, Int.add_mul_emod_self_right]
 
 /-- `wrapInt` result is congruent to `x` modulo the period `(high - low)`. -/
-theorem wrapInt_congruent (x low high : Int) (h : low < high) :
+theorem wrapInt_congruent (x low high : Int) (_h : low < high) :
     ∃ k : Int, wrapInt x low high = x + k * (high - low) := by
   unfold wrapInt
   refine ⟨-((x - low) / (high - low)), ?_⟩


### PR DESCRIPTION
🔬 Lean Squad automated formal verification.

## Task 3: MedianFilter Lean spec (phase 2→5)
- Add formal-verification/lean/FVSquad/MedianFilter.lean
  - Abstract median over List Int using List.mergeSort
  - Proved mfMedian_mem: result is a member of the input window
  - Proved mfMedian_const: constant window returns that value
  - Proved mfMedian_ge_sorted_first: median >= min element (window >= 3)
  - Proved mfMedian_le_sorted_last: median <= max element (window >= 3)
  - Proved mfInsert_lt: head stays in bounds after insert
  - Proved mfInsert_head_wraps: head wraps to 0 after last slot
  - 6 concrete native_decide examples (window=3 and window=5)
  - lake build passes, 0 sorry
- Update FVSquad/Basic.lean barrel to import MedianFilter
- Update TARGETS.md: MedianFilter phase 2 -> 5

## Task 9: CI improvement
- Add 'lake update' step before 'lake build' in lean-ci.yml
  so Lean dependency manifest is always resolved before building

## Linter warning cleanup (8 warnings fixed)
- AlphaFilter.lean: rename ha0 -> _ha0 in 3 theorems (unused)
- Deadzone.lean: rename hdz0 -> _hdz0 in 2 theorems (unused)
- Expo.lean: remove unused Rat.mul_one simp arg; rename h/he -> _h/_he
- WrapAngle.lean: rename h -> _h in 4 theorems (unused by omega)

## Verification status
- lake build: PASSED (Lean 4.29.0, 0 new sorry, 6 pre-existing WrapAngle sorry)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
